### PR TITLE
Add support for structs and support implicitly generating properties instead of fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Belows are the rules to convert from UML model elements to C# source codes.
 * Documentation property to C#Doc comment.
 * Annotation Type is converted to C# attribute class which extends System.Attribute and postfix of class is Attribute.
   (cf. class testAttribute:System.Attribute)
+* If `stereotype` = `struct` then converted to _C# Struct_.
 
 ### UMLAttribute
 

--- a/code-generator.js
+++ b/code-generator.js
@@ -632,7 +632,7 @@ class CSharpCodeGenerator {
       }
 
       // property
-      if (elem.stereotype === 'property') {
+      if (elem.stereotype === 'property' || (options.propertiesByDefault && codegen.isEmpty(elem.stereotype))) {
         codeWriter.writeLine(terms.join(' ') + ' {')
         codeWriter.indent()
         if (elem.isReadOnly) {

--- a/code-generator.js
+++ b/code-generator.js
@@ -399,7 +399,11 @@ class CSharpCodeGenerator {
     }
 
     // Class
-    terms.push('class')
+    if(elem.stereotype === 'struct'){
+      terms.push('struct')
+    }else{
+      terms.push('class')
+    }
     terms.push(elem.name)
 
     // Extends

--- a/codegen-utils.js
+++ b/codegen-utils.js
@@ -76,3 +76,9 @@ class CodeWriter {
 }
 
 exports.CodeWriter = CodeWriter
+
+function isEmpty(str) {
+  return !str || str.match(/^ *$/) !== null;
+}
+
+exports.isEmpty = isEmpty;

--- a/main.js
+++ b/main.js
@@ -28,7 +28,8 @@ function getGenOptions () {
   return {
     csharpDoc: app.preferences.get('csharp.gen.csharpDoc'),
     useTab: app.preferences.get('csharp.gen.useTab'),
-    indentSpaces: app.preferences.get('csharp.gen.indentSpaces')
+    indentSpaces: app.preferences.get('csharp.gen.indentSpaces'),
+    propertiesByDefault: app.preferences.get('csharp.gen.propertiesByDefault')
   }
 }
 

--- a/preferences/preference.json
+++ b/preferences/preference.json
@@ -24,6 +24,12 @@
       "type": "number",
       "default": 4
     },
+    "csharp.gen.propertiesByDefault": {
+      "text": "Properties instead of fields",
+      "description": "Generate properties instead of fields if not explictly specified.",
+      "type": "check",
+      "default": false
+    },
     "csharp.rev": {
       "text": "C# Reverse Engineering",
       "type": "section"


### PR DESCRIPTION
1. You can generate structs now by providing stereotype `struct`.

2. I added a parameter which let's you output properties instead of fields without explicitly specifying a stereotype. I left it off by default. 